### PR TITLE
update dss-proxy-actions.allow to use uint instead of bool for dss-cdp-manager

### DIFF
--- a/src/DssProxyActions.sol
+++ b/src/DssProxyActions.sol
@@ -30,7 +30,7 @@ contract ManagerLike {
     function vat() public view returns (address);
     function open(bytes32) public returns (uint);
     function give(uint, address) public;
-    function allow(uint, address, bool) public;
+    function allow(uint, address, uint) public;
     function frob(uint, int, int) public;
     function frob(uint, address, int, int) public;
     function flux(uint, address, uint) public;
@@ -170,7 +170,7 @@ contract DssProxyActions {
         address manager,
         uint cdp,
         address guy,
-        bool ok
+        uint ok
     ) public {
         ManagerLike(manager).allow(cdp, guy, ok);
     }

--- a/src/DssProxyActions.t.sol
+++ b/src/DssProxyActions.t.sol
@@ -23,7 +23,7 @@ contract ProxyCalls {
         proxy.execute(proxyLib, msg.data);
     }
 
-    function allow(address, uint, address, bool) public {
+    function allow(address, uint, address, uint) public {
         proxy.execute(proxyLib, msg.data);
     }
 
@@ -171,7 +171,7 @@ contract DssProxyActionsTest is DssDeployTestBase, ProxyCalls {
     function testGiveCDPAllowedUser() public {
         uint cdp = this.open(address(manager), "ETH");
         FakeUser user = new FakeUser();
-        this.allow(address(manager), cdp, address(user), true);
+        this.allow(address(manager), cdp, address(user), 1);
         user.doGive(manager, cdp, address(123));
         assertEq(manager.lads(cdp), address(123));
     }


### PR DESCRIPTION
depends on `dss-cdp-manager` PR: https://github.com/makerdao/dss-cdp-manager/pull/10

Changing `ManagerLike.allow` to use `uint` instead of `bool` has a slight gas improvement, but requires changing the proxy-actions to accept and forward `uint` instead of `bool`.  

Note: this does not include a change/update to the submodule, but I manually made the change and the tests passed.  I assumed the process would be to merge `dss-cdp-manager` first, then update this to point the submodule at the correct master version 