### PR TITLE
Implementation of CDP migration between two different CDP managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ https://github.com/makerdao/dss-proxy-actions
 
 `shift(address manager, uint cdpSrc, uint cdpDst)`: moves `cdpSrc` collateral balance and debt to `cdpDst`.
 
+`shiftManager(address managerSrc, address managerDst, uint cdpSrc, uint cdpDst)`: moves `cdpSrc` collateral balance from and debt from `managerSrc` to `cdpDst` in `managerDst`.
+
 `lockETH(address manager, address ethJoin, uint cdp)`: deposits `msg.value` amount of ETH in `ethJoin` adapter and executes `frob` to `cdp` increasing the locked value.
 
 `safeLockETH(address manager, address ethJoin, uint cdp, address owner)`: same than `lockETH` but requiring `owner == cdp owner`.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://github.com/makerdao/dss-proxy-actions
 
 `shift(address manager, uint cdpSrc, uint cdpDst)`: moves `cdpSrc` collateral balance and debt to `cdpDst`.
 
-`shiftManager(address managerSrc, address managerDst, uint cdpSrc, uint cdpDst)`: moves `cdpSrc` collateral balance from and debt from `managerSrc` to `cdpDst` in `managerDst`.
+`shiftManager(address managerSrc, address managerDst, uint cdpSrc, uint cdpDst)`: moves `cdpSrc` collateral balance and debt from `managerSrc` to `cdpDst` in `managerDst`.
 
 `lockETH(address manager, address ethJoin, uint cdp)`: deposits `msg.value` amount of ETH in `ethJoin` adapter and executes `frob` to `cdp` increasing the locked value.
 

--- a/src/DssProxyActions.sol
+++ b/src/DssProxyActions.sol
@@ -656,6 +656,18 @@ contract DssProxyActions is Common {
         lockETHAndDraw(manager, jug, ethJoin, daiJoin, cdp, wadD);
     }
 
+    function openLockETHAndGiveToProxy(
+        address proxyRegistry,
+        address manager,
+        address ethJoin,
+        bytes32 ilk,
+        address dst
+    ) public payable returns (uint cdp) {
+        cdp = open(manager, ilk, address(this));
+        lockETH(manager,ethJoin,cdp);
+        giveToProxy(proxyRegistry,manager,cdp,dst);
+    }
+
     function lockGemAndDraw(
         address manager,
         address jug,

--- a/src/DssProxyActions.sol
+++ b/src/DssProxyActions.sol
@@ -363,6 +363,28 @@ contract DssProxyActions is Common {
         ManagerLike(manager).shift(cdpSrc, cdpOrg);
     }
 
+    function shiftManager(
+      	address managerSrc,
+      	address managerDst,
+      	uint cdpSrc,
+      	uint cdpDst
+    ) public {
+        address vat = ManagerLike(managerSrc).vat();
+      	require(vat == ManagerLike(managerDst).vat(), "vat-mismatch");
+
+      	bool canSrc = (VatLike(vat).can(address(this), managerSrc) != 0);
+      	bool canDst = (VatLike(vat).can(address(this), managerDst) != 0);
+
+      	if(! canSrc) hope(vat, managerSrc);
+      	if(! canDst) hope(vat, managerDst);
+
+      	quit(managerSrc, cdpSrc, address(this));
+      	enter(managerDst, address(this), cdpDst);
+
+      	if(! canSrc) nope(vat, managerSrc);
+      	if(! canDst) nope(vat, managerDst);
+    }
+
     function makeGemBag(
         address gemJoin
     ) public returns (address bag) {

--- a/src/DssProxyActions.t.sol
+++ b/src/DssProxyActions.t.sol
@@ -712,6 +712,23 @@ contract DssProxyActionsTest is DssDeployTestBase, ProxyCalls {
         assertEq(address(this).balance, initialBalance - 2 ether);
     }
 
+    function testOpenLockETHAndGiveToProxyNewProxy() public {
+        address user = address(0x123);
+        uint cdp = DssProxyActions(dssProxyActions).openLockETHAndGiveToProxy.value(2 ether)(address(registry),address(manager),address(ethJoin),"ETH",user);
+        assertEq(ink("ETH", manager.urns(cdp)), 2 ether);
+        DSProxy userProxy = registry.proxies(user);
+        assertEq(manager.owns(cdp), address(userProxy));
+    }
+
+    function testOpenLockETHAndGiveToProxyExistingProxy() public {
+        address user = address(0x123);
+        registry.build(user);
+        DSProxy userProxy = registry.proxies(user);        
+        uint cdp = DssProxyActions(dssProxyActions).openLockETHAndGiveToProxy.value(2 ether)(address(registry),address(manager),address(ethJoin),"ETH",user);
+        assertEq(ink("ETH", manager.urns(cdp)), 2 ether);
+        assertEq(manager.owns(cdp), address(userProxy));
+    }
+
     function testLockGemAndDraw() public {
         col.mint(5 ether);
         uint cdp = this.open(address(manager), "COL", address(proxy));


### PR DESCRIPTION
I am working on an alternative-backwards-compatible CDP manager, and would like to have a functionality to migrate CDPs between managers.
This PR implements `shiftManager` function with the following semantic:


`shiftManager(address managerSrc, address managerDst, uint cdpSrc, uint cdpDst)`: moves cdpSrc collateral balance and debt from managerSrc to cdpDst in managerDst.


I believe this could be useful for other projects as well, and thus it would make sense to make it standard in the main repository.